### PR TITLE
meta.yaml: Update earthengine-api to require 1.6.13

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @giswqs @jdbcode @naschmitz
+* @giswqs @jdbcode @naschmitz @schwehr

--- a/README.md
+++ b/README.md
@@ -152,4 +152,5 @@ Feedstock Maintainers
 * [@giswqs](https://github.com/giswqs/)
 * [@jdbcode](https://github.com/jdbcode/)
 * [@naschmitz](https://github.com/naschmitz/)
+* [@schwehr](https://github.com/schwehr/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - anywidget
     - bqplot
     - colour
-    - earthengine-api >=1.5.12
+    - earthengine-api >=1.6.13
     - eerepr >=0.1.0
     - ffmpeg-python
     - folium >=0.17.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "geemap" %}
 {% set version = "0.36.6" %}
-{% set python_min = "3.9" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,3 +78,4 @@ extra:
     - giswqs
     - jdbcode
     - naschmitz
+    - schwehr


### PR DESCRIPTION
1.6.12 should probably work, but be safe and go with the current newest version.

See:

* https://github.com/gee-community/geemap/commit/5f370bd8b99dd37d1c903df34ab2ec2c97ced1a9
* https://github.com/google/earthengine-api/commit/f22d01a6db2b362f68a917b88fa82b0ac5838176

https://github.com/conda-forge/geemap-feedstock/pull/202 failed with:

> geemap 0.36.6 has requirement earthengine-api>=1.6.12, but you have earthengine-api 1.6.3.

I'm not sure which of these are relevant:

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
